### PR TITLE
Include 1985 in SFm data transform path list

### DIFF
--- a/scripts/data transformation/SFm.py
+++ b/scripts/data transformation/SFm.py
@@ -35,7 +35,7 @@ path_1975 = 'Analysis/SFm_SEER Rated AC_HP_1975'
 path_1985 = 'Analysis/SFm_SEER Rated AC_HP_1985'
 path_new = ''
 
-paths = [path_1975, path_1975]
+paths = [path_1975, path_1985]
 
 if path_new != '' :
     paths = [path_new]


### PR DESCRIPTION
Fix typo in paths. For SFm.py to process existing vintage, we need to give paths to two folders (1975 and 1985 variants).

This line was changed in commit 878e949; prior to that it worked correctly.