### PR TITLE
Update hw.pxt to address plant overheating fatal errors 

### DIFF
--- a/templates/energyplus/templates/system/hw.pxt
+++ b/templates/energyplus/templates/system/hw.pxt
@@ -309,10 +309,10 @@ Pump:VariableSpeed,
   <%= pump_power %>,  !- Rated Power Consumption {W}
   <%= pump_eff %>,  !- Motor Efficiency
   0.0,                     !- Fraction of Motor Inefficiencies to Fluid Stream
-  0,                       !- Coefficient 1 of the Part Load Performance Curve
-  3.2485,                       !- Coefficient 2 of the Part Load Performance Curve
-  -4.7443,                       !- Coefficient 3 of the Part Load Performance Curve
-  2.5295,                       !- Coefficient 4 of the Part Load Performance Curve
+  0.0273,                       !- Coefficient 1 of the Part Load Performance Curve
+  -0.1317,                       !- Coefficient 2 of the Part Load Performance Curve
+  0.6642,                       !- Coefficient 3 of the Part Load Performance Curve
+  0.4445,                       !- Coefficient 4 of the Part Load Performance Curve
   0.0,                     !- Minimum Flow Rate {m3/s}
 <% if (pump_control == "CONTINUOUS") %>
   Continuous;              !- Pump Control Type


### PR DESCRIPTION
Per DEER Support call on 2/7/2024, I am submitting this request to address plant overheating errors in models relying on hot water space heating.

Running all commercial building type/vintage/CZ combinations results in the following simulations failing:

Climate Zone Building Type Code Vintages 
CZ03   NRS   1995 VINTAGE 
CZ04   MLI   2016 THRU 2022 VINTAGES 
CZ06   MLI   2013 THRU 2022 VINTAGES 
CZ06   RT3   1975 THRU 1985 VINTAGES 
CZ07   MLI   2016 THRU 2022 VINTAGES 
CZ07   RT3   ALL VINTAGES 
CZ08   MLI   2008 THRU 2022 VINTAGES 
CZ08   RT3   ALL VINTAGES 
CZ09   MLI   2016 THRU 2022 VINTAGES 
CZ09   RT3   ALL VINTAGES 
CZ10   MLI   2016 THRU 2022 VINTAGES 
CZ10   RT3   ALL VINTAGES 
CZ11   RT3   1995 THRU 2001 VINTAGES 
CZ13   HTL   1975 VINTAGE 
CZ13   RT3   1995 THRU 2001 VINTAGES 
CZ14   RT3   1995 THRU 2001 VINTAGES 
CZ15   MLI   2008 THRU 2022 VINTAGES 
CZ15   RT3   1975 THRU 2001 VINTAGES 

After inspecting the error files, it appears that the same root cause is at issue for nearly all of the models. The hot water loop that is used in each model to provide space heat to one or more zones encounters a fatal “runaway temperature” situation. This runaway temperature issue appears to occur during the summer months, where a minimal amount of space heating is required for a short period of time when transitioning from an unoccupied “setback” temperature to an occupied temperature. The amount of space heating is very small, and inspection of the hot water pump outlet temperature for one working prototype combination (MLI/2013 vintage/CZ04) shows that, during the summer months, the pump heat imparted to the working fluid exceeds the heat needed by the heating coils during this temperature recovery period. Also, the hot water loop used in the models is an “adiabatic” loop, meaning that there is zero heat loss from working fluid in the loop piping. In the one model I inspected, the hot water loop reached temperatures exceeding 240°F by early September before significant heating loads bring the loop back toward its intended 180°F setpoint. This suggests that the issue affects all models using the adiabatic hot water loop, even if only certain vintages may fail due to runaway loop temperatures. I am attaching the hourly output file that supports my conclusion; column H (pump shaft power) confirms the intermittent operation of the pump, while Column I shows the pump outlet temperature. The peak temperature for this model is achieved on Sept 14 @23:00. (output attached)
[instance MLI 2015 CZ4 adiabatic.xlsx](https://github.com/sound-data/DEER-Prototypes-EnergyPlus/files/14199794/instance.MLI.2015.CZ4.adiabatic.xlsx)
 
The amount of pumping energy added to the hot water loop is dictated by the hot water pump design kW and the part-load power/flow profile, as defined by the pump coefficients. The current hot water pump coefficients in hw.pxt reflect a pump that “rides the curve”; this profile injects a significant fraction of pumping energy into the working fluid even at very low flow percentages (e.g., a pump that is flowing 30% of capacity will require 61.6% of design kW). When I compare the DEER prototypes with previously-built CalBEM models as well as example commercial prototype models from the CBECC software, it appears that the latter categories of models use hot water pump coefficients that correspond to VFD pump control; with those coefficients, the same 30% flow would require only 6% of design kW. When the VSD coefficients are substituted in the hw.pxt file and models rerun, all of them successfully run, except for the 1975 Hotel/CZ13 combination, which appears to have unique issues not discussed here. I attached a spreadsheet comparing the effects of the the pump coefficients on the flow/power profile.
[hw pump coefficient comparison.xlsx](https://github.com/sound-data/DEER-Prototypes-EnergyPlus/files/14199720/hw.pump.coefficient.comparison.xlsx)

The root cause issue here appears to be that the adiabatic hot water loop has no mechanism to accommodate ordinary heat losses. The existing loop design is consistent with the EnergyPlus Plant Application Guide, but a long-term resolution to this issue would involve substituting a length of indoor pipe, with insulation, for one of the adiabatic pipes that the Guide recommends. I was able to modify [one] idf file in such a manner by replacing an adiabatic pipe from the pump output, and this modification, if designed properly, would introduce a small heat loss from the hot water loop that more closely mirrors actual piping implementations. However, I suspect that making such modifications to the hw.pxt file would be very time-intensive, as it would require developing some method to determine the optimal heat loss and codify it within the existing Ruby code. It may also require vetting with the EnergyPlus team to ensure the appropriateness of the solution given the guidance in their existing documentation.
 
A more expeditious work-around, which I recommend for adoption at this time, is to replace the existing hot water pump coefficients (lines 312 to 315 of hw.pxt) with the coefficients used by CBECC and CalBEM models. The existing coefficients are:
 
0,                          !- Coefficient 1 of the Part Load Performance Curve
3.2485,                   !- Coefficient 2 of the Part Load Performance Curve
-4.7443,                  !- Coefficient 3 of the Part Load Performance Curve
2.5295,                   !- Coefficient 4 of the Part Load Performance Curve
 
0.0273,                   !- Coefficient 1 of the Part Load Performance Curve
-0.1317,                  !- Coefficient 2 of the Part Load Performance Curve
0.6642,                   !- Coefficient 3 of the Part Load Performance Curve
0.4445,                   !- Coefficient 4 of the Part Load Performance Curve
 
This modification appears to allow all prototypes to run (with the exception of the single hotel model mentioned previously), based on local testing. It does not address the adiabatic nature of the plant loop, but the heat introduced by the pump is reduced to a level where runaway loop temperatures are effectively eliminated. Additionally, the hot water pump energy is a relatively small fraction of the total energy used by the HVAC system, so using these modified coefficients should not materially affect the models’ baseline energy use. It is also consistent with the CBECC 2022 software.