### PR TITLE
Remove extra space after "dimensionless" symbol

### DIFF
--- a/templates/energyplus/templates/system/unitary.pxt
+++ b/templates/energyplus/templates/system/unitary.pxt
@@ -532,8 +532,8 @@ Curve:Quartic,
   1.0 ,                                !- Maximum Value of x
   0.0 ,                                !- Minimum Curve Output
   1.0 ,                                !- Maximum Curve Output
-  Dimensionless ,                      !- Input Unit Type for X
-  Dimensionless ;                      !- Output Unit Type
+  Dimensionless,                      !- Input Unit Type for X
+  Dimensionless;                      !- Output Unit Type
 <% end %>
 
 <% elsif (fan_type == "VARIABLE") %>


### PR DESCRIPTION
# Pull Request (PR) Description

In unitary template, under Curve:Quartic supply fan curves, there is a space after "Dimensionless" symbol in input/output unit types. IDF Editor highlights these inputs (does not recognize the symbol). However, the simulation runs without error. So, this is just a style edit to remove the extra space and get IDF Editor to display lines as normal.

![Screenshot 2024-03-18 125606](https://github.com/sound-data/DEER-Prototypes-EnergyPlus/assets/48603739/2d5095ee-e9d0-4b2c-b20e-16699d92d953)

### PR Author
- [x] Craft a succinct title that effectively encapsulates the essence of the pull request, providing a general overview of the proposed changes.
- [ ] Label the PR with at least one of the following: New Measure, Bug, or Feature.
- [x] Provide a concise description of the measure, bug, or feature. Submit one PR per measure.
- N/A For a new measure, attach a workbook named DEER_EnergyPlus_Modelkit_Measure_list_working.xlsx, containing only rows used for post-processing the measure.
- N/A Add comments in the code when necessary to facilitate the review process.
- N/A Add a comment before the added code, including the author's full name, company, and specifying if it's a bug fix, new measure, or feature.
- N/A For a new feature or bug, demonstrate the impact on energy consumption for selected cases with justification using plots and descriptions.
- N/A For a new measure, add a summary table showing total energy consumption per simulated case.
### PR Reviewer
- [ ] Conduct a thorough code review.
- [ ] If the branch is behind the main, merge the branch locally to check for potential conflicts.
- [ ] If a bug, locally reproduce it and compare energy consumptions before and after.
- [ ] Explore creative ways to stress-test the code.
- [ ] Locally check the error file and other outputs.

