### PR TITLE
Bug - Enforce rules for refrigeration:compressor inputs

### DIFF
--- a/templates/energyplus/templates/ref-sys-comp.pxt
+++ b/templates/energyplus/templates/ref-sys-comp.pxt
@@ -2,10 +2,33 @@
 parameter "comp_name"
 parameter "comp_curves_source", :default=>"Carlyle_R-22_Med_06DM808" # (Carlyle_R-22_Low_06CC665 | Carlyle_R-22_Low_06DR718 | Carlyle_R-22_Med_06DM808 | Carlyle_R-22_Med_06DR820 | Copeland_R507_Med_3DS3150ETFE |Copeland_R507_Med_2da3075e | 
 # Copeland_R507_Low_3db30750 | Copeland_R507_Low_3DS3100E |Copeland_R507_Low_4dl3150e | Copeland_R507_Med_3db3100e)
-parameter "rated_sh", :default=>5
+parameter "rated_sh", :default=>"" # ['C']
 parameter "return_gas_temp", :default=>18['C']
 parameter "liquid_temp", :default=>4.4['C']
-parameter "rated_subcooling", :default=>""
+parameter "rated_subcooling", :default=>"" # ['C']
+%>
+
+<%
+# 2024-04-03 Nicholas Fette on advice from Roger Baker
+# EnergyPlus expects at most one input from these:
+# * rated superheat (rated_sh)
+# * rated return gas temperature (return_gas_temp)
+
+# Rules with a "not equals" comparison are not yet implemented.
+#rule "return_gas_given", :condition => Proc.new {return_gas_temp != ""} do
+#  force :rated_sh => ""
+#end
+if return_gas_temp != ""
+  rated_sh = ""
+end
+
+# EnergyPlus expects at most one input from these:
+# * rated liquid temperature (liquid_temp)
+# * rated subcooling (rated_subcooling)
+if liquid_temp != ""
+  rated_subcooling = ""
+end
+
 %>
 
 Refrigeration:Compressor,


### PR DESCRIPTION
# Pull Request (PR) Description

Enforce rules for refrigeration:compressor inputs.

1. EnergyPlus expects at most one input from these:
  * rated superheat (rated_sh)
  * rated return gas temperature (return_gas_temp)
2. EnergyPlus expects at most one input from these:
  * rated liquid temperature (liquid_temp)
  * rated subcooling (rated_subcooling)

See discussion #41 and reference documentation for [Refrigeration:Compressor](https://bigladdersoftware.com/epx/docs/22-2/input-output-reference/group-refrigeration.html#refrigerationcompressor).

### PR Author
- [x] Make sure the PR branch is up to date with main branch at the time of the PR submission
- [x] Craft a succinct title that effectively encapsulates the essence of the pull request, providing a general overview of the proposed changes.
- [x] Label the PR with at least one of the following: New Measure, Bug, or Feature.
- [x] Provide a concise description of the measure, bug, or feature. Submit one PR per measure.
- N/A - For a new measure, attach a workbook named DEER_EnergyPlus_Modelkit_Measure_list_working.xlsx, containing only rows used for post-processing the measure.
- [x] Add comments in the code when necessary to facilitate the review process.
- [x] Add a comment before the added code, including the author's full name, company, and specifying if it's a bug fix, new measure, or feature.
- N/A - For a new feature or bug, demonstrate the impact on energy consumption for selected cases with justification using plots and descriptions.
- N/A - For a new measure, add a summary table showing total energy consumption per simulated case.
### PR Reviewer
- [ ] Conduct a thorough code review.
- [ ] If the branch is behind the main, merge the branch locally to check for potential conflicts.
- [ ] If a bug, locally reproduce it and compare energy consumptions before and after.
- [ ] Explore creative ways to stress-test the code.
- [ ] Locally check the error file and other outputs.
