### PR TITLE
Com.py duplicate rows where more than one "Common_PreTechID" [bug]

### DIFF
--- a/scripts/data transformation/Com.py
+++ b/scripts/data transformation/Com.py
@@ -558,9 +558,13 @@ metadata_msr = metadata_msr.rename(columns={'TechID':'MeasTechID'})
 # commom_preTechID = PreTechIDs['Common_PreTechID'].unique()[0]
 if False in list(PreTechIDs['PreTechID']==PreTechIDs['Common_PreTechID']):
     metadata_pre_full = pd.DataFrame()
-    for new_id in PreTechIDs['PreTechID']:
+    # Solaris Technical 2024-04-17
+    # Corrects an issue where more than one "Common_PreTechID" in
+    # the batch of measures causes the renaming step to fail silently
+    # and generate duplicate rows with mismatched data.
+    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']]:
         print(f'changing to specific PreTechID {new_id}')
-        metadata_pre_mod = metadata_pre.copy()
+        metadata_pre_mod = metadata_pre[metadata_pre['PreTechID']==common_id].copy()
         metadata_pre_mod['PreTechID'] = new_id
         #merge to final df
         metadata_pre_full = pd.concat([metadata_pre_full, metadata_pre_mod])
@@ -656,9 +660,10 @@ sim_annual_msr_common = sim_annual_f[sim_annual_f['TechID'].isin(MeasTechIDs['Co
 # commom_preTechID = PreTechIDs['Common_PreTechID'].unique()[0]
 if False in list(PreTechIDs['PreTechID']==PreTechIDs['Common_PreTechID']):
     sim_annual_pre = pd.DataFrame()
+    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']]:
     for new_id in PreTechIDs['PreTechID']:
         print(f'changing to specific PreTechID {new_id}')
-        sim_annual_pre_mod = sim_annual_pre_common.copy()
+        sim_annual_pre_mod = sim_annual_pre_common[sim_annual_pre_common['TechID']==common_id].copy()
         sim_annual_pre_mod['TechID'] = new_id
         #merge to final df
         sim_annual_pre = pd.concat([sim_annual_pre, sim_annual_pre_mod])
@@ -711,9 +716,9 @@ sim_hourly_msr_common = sim_hourly_f[sim_hourly_f['TechID'].isin(MeasTechIDs['Co
 #Pre hourly
 if False in list(PreTechIDs['PreTechID']==PreTechIDs['Common_PreTechID']):
     sim_hourly_pre = pd.DataFrame()
-    for new_id in PreTechIDs['PreTechID']:
+    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']]:
         print(f'changing to specific PreTechID {new_id}')
-        sim_hourly_pre_mod = sim_hourly_pre_common.copy()
+        sim_hourly_pre_mod = sim_hourly_pre_common[sim_hourly_pre_common['TechID']==common_id].copy()
         sim_hourly_pre_mod['TechID'] = new_id
         #merge to final df
         sim_hourly_pre = pd.concat([sim_hourly_pre, sim_hourly_pre_mod])

--- a/scripts/data transformation/Com.py
+++ b/scripts/data transformation/Com.py
@@ -562,7 +562,7 @@ if False in list(PreTechIDs['PreTechID']==PreTechIDs['Common_PreTechID']):
     # Corrects an issue where more than one "Common_PreTechID" in
     # the batch of measures causes the renaming step to fail silently
     # and generate duplicate rows with mismatched data.
-    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']]:
+    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']].iterrows():
         print(f'changing to specific PreTechID {new_id}')
         metadata_pre_mod = metadata_pre[metadata_pre['PreTechID']==common_id].copy()
         metadata_pre_mod['PreTechID'] = new_id
@@ -660,7 +660,7 @@ sim_annual_msr_common = sim_annual_f[sim_annual_f['TechID'].isin(MeasTechIDs['Co
 # commom_preTechID = PreTechIDs['Common_PreTechID'].unique()[0]
 if False in list(PreTechIDs['PreTechID']==PreTechIDs['Common_PreTechID']):
     sim_annual_pre = pd.DataFrame()
-    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']]:
+    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']].iterrows():
     for new_id in PreTechIDs['PreTechID']:
         print(f'changing to specific PreTechID {new_id}')
         sim_annual_pre_mod = sim_annual_pre_common[sim_annual_pre_common['TechID']==common_id].copy()
@@ -716,7 +716,7 @@ sim_hourly_msr_common = sim_hourly_f[sim_hourly_f['TechID'].isin(MeasTechIDs['Co
 #Pre hourly
 if False in list(PreTechIDs['PreTechID']==PreTechIDs['Common_PreTechID']):
     sim_hourly_pre = pd.DataFrame()
-    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']]:
+    for _, (common_id, new_id) in PreTechIDs[['Common_PreTechID','PreTechID']].iterrows():
         print(f'changing to specific PreTechID {new_id}')
         sim_hourly_pre_mod = sim_hourly_pre_common[sim_hourly_pre_common['TechID']==common_id].copy()
         sim_hourly_pre_mod['TechID'] = new_id


### PR DESCRIPTION
# Pull Request (PR) Description

Corrects an issue where more than one "Common_PreTechID" in the batch of measures causes the renaming step to fail silently and generate duplicate rows with mismatched data.

This change was previously applied in residential scripts via PR #19, commit 9da1f04.

### PR Author
- [x] Make sure the PR branch is up to date with main branch at the time of the PR submission
- [x] Craft a succinct title that effectively encapsulates the essence of the pull request, providing a general overview of the proposed changes.
- [x] Label the PR with at least one of the following: New Measure, **Bug**, or Feature.
- [x] Provide a concise description of the measure, bug, or feature. Submit one PR per measure.
- N/A - For a new measure, attach a workbook named DEER_EnergyPlus_Modelkit_Measure_list_working.xlsx, containing only rows used for post-processing the measure.
- [x] Add comments in the code when necessary to facilitate the review process.
- [x] Add a comment before the added code, including the author's full name, company, and specifying if it's a bug fix, new measure, or feature.
- N/A - For a new feature or bug, demonstrate the impact on energy consumption for selected cases with justification using plots and descriptions.
- N/A - For a new measure, add a summary table showing total energy consumption per simulated case.
### PR Reviewer
- [ ] Conduct a thorough code review.
- [ ] If the branch is behind the main, merge the branch locally to check for potential conflicts.
- [ ] If a bug, locally reproduce it and compare energy consumptions before and after.
- [ ] Explore creative ways to stress-test the code.
- [ ] Locally check the error file and other outputs.
