### PR TITLE
Align commercial RunPeriod calendar to CEC reference year (Thu-start, non-leap)

### DIFF
--- a/templates/energyplus/templates/general.pxt
+++ b/templates/energyplus/templates/general.pxt
@@ -94,7 +94,7 @@ RunPeriod,
   Thursday,                  !- Day of Week for Start Day
   No,                      !- Use Weather File Holidays and Special Days
   No,                      !- Use Weather File Daylight Saving Period
-  No,                      !- Apply Weekend Holiday Rule
+  Yes,                      !- Apply Weekend Holiday Rule
   Yes,                     !- Use Weather File Rain Indicators
   Yes;                     !- Use Weather File Snow Indicators
 <% elsif run_control == "TEST" %>
@@ -109,7 +109,7 @@ RunPeriod,
   Thursday,                  !- Day of Week for Start Day
   No,                      !- Use Weather File Holidays and Special Days
   No,                      !- Use Weather File Daylight Saving Period
-  No,                      !- Apply Weekend Holiday Rule
+  Yes,                      !- Apply Weekend Holiday Rule
   Yes,                     !- Use Weather File Rain Indicators
   Yes;                     !- Use Weather File Snow Indicators
 <% end %>

--- a/templates/energyplus/templates/general.pxt
+++ b/templates/energyplus/templates/general.pxt
@@ -92,8 +92,8 @@ RunPeriod,
   31,                      !- End Day of Month
   ,                        !- End Year
   Thursday,                  !- Day of Week for Start Day
-  No,                      !- Use Weather File Holidays and Special Days
-  No,                      !- Use Weather File Daylight Saving Period
+  Yes,                      !- Use Weather File Holidays and Special Days
+  Yes,                      !- Use Weather File Daylight Saving Period
   Yes,                      !- Apply Weekend Holiday Rule
   Yes,                     !- Use Weather File Rain Indicators
   Yes;                     !- Use Weather File Snow Indicators
@@ -107,8 +107,8 @@ RunPeriod,
   1,                       !- End Day of Month
   ,                        !- End Year
   Thursday,                  !- Day of Week for Start Day
-  No,                      !- Use Weather File Holidays and Special Days
-  No,                      !- Use Weather File Daylight Saving Period
+  Yes,                      !- Use Weather File Holidays and Special Days
+  Yes,                      !- Use Weather File Daylight Saving Period
   Yes,                      !- Apply Weekend Holiday Rule
   Yes,                     !- Use Weather File Rain Indicators
   Yes;                     !- Use Weather File Snow Indicators

--- a/templates/energyplus/templates/general.pxt
+++ b/templates/energyplus/templates/general.pxt
@@ -91,7 +91,7 @@ RunPeriod,
   12,                      !- End Month
   31,                      !- End Day of Month
   ,                        !- End Year
-  Sunday,                  !- Day of Week for Start Day
+  Thursday,                  !- Day of Week for Start Day
   No,                      !- Use Weather File Holidays and Special Days
   No,                      !- Use Weather File Daylight Saving Period
   No,                      !- Apply Weekend Holiday Rule
@@ -106,7 +106,7 @@ RunPeriod,
   1,                       !- End Month
   1,                       !- End Day of Month
   ,                        !- End Year
-  Sunday,                  !- Day of Week for Start Day
+  Thursday,                  !- Day of Week for Start Day
   No,                      !- Use Weather File Holidays and Special Days
   No,                      !- Use Weather File Daylight Saving Period
   No,                      !- Apply Weekend Holiday Rule


### PR DESCRIPTION
# Pull Request (PR) Description
This PR updates the shared commercial template templates/energyplus/templates/general.pxt to align commercial prototype simulations with a non-leap reference year that starts on a Thursday (e.g., 2009). This is needed so that day-of-week alignment matches the CEC reference-year convention when using updated climate-zone weather (CZ2025) and related peak-day analysis workflows.

**DEER Support Email: DeerSupport@guidehouse.com**

What changed: templates/energyplus/templates/general.pxt
For both RunPeriod blocks (run_control == "RUNPERIOD" and run_control == "TEST"), updated:
Day of Week for Start Day: Sunday → Thursday
Use Weather File Holidays and Special Days: No → Yes
Use Weather File Daylight Saving Period: No → Yes
Apply Weekend Holiday Rule: No → Yes
No other files are modified in this PR.

Why this change is needed
Commercial prototypes historically used a default “Sunday start-day” year, which does not match the intended CEC-style reference-year weekday alignment (Thursday start-day; e.g., 2009).
CZ2025 EPW files reviewed do not embed holidays, so holidays/special days must be established in the model inputs/templates (IDF/Modelkit), not assumed to come from the EPW. Enabling these RunPeriod flags supports a consistent calendar configuration and does not preclude defining holidays explicitly via RunPeriodControl:SpecialDays where applicable.

### PR Author
- [ ] Make sure the PR branch is up to date with main branch at the time of the PR submission
- [ ] Craft a succinct title that effectively encapsulates the essence of the pull request, providing a general overview of the proposed changes.
- [ ] Label the PR with at least one of the following: New Measure, Bug, or Feature.
- [x] Provide a concise description of the measure, bug, or feature. Submit one PR per measure.
- [ ] For a new measure, attach a workbook named DEER_EnergyPlus_Modelkit_Measure_list_working.xlsx, containing only rows used for post-processing the measure.
- [ ] Add comments in the code when necessary to facilitate the review process.
- [ ] Add a comment before the added code, including the author's full name, company, and specifying if it's a bug fix, new measure, or feature.
- [ ] For a new feature or bug, demonstrate the impact on energy consumption for selected cases with justification using plots and descriptions.
- [ ] For a new measure, add a summary table showing total energy consumption per simulated case.
### PR Reviewer
- [ ] Conduct a thorough code review.
- [ ] If the branch is behind the main, merge the branch locally to check for potential conflicts.
- [ ] If a bug, locally reproduce it and compare energy consumptions before and after.
- [ ] Explore creative ways to stress-test the code.
- [ ] Locally check the error file and other outputs.
