### PR TITLE
Improvement - bug fix for hvac-zone.pxt

### DIFF
--- a/templates/energyplus/templates/zonehvac/hvac-zone.pxt
+++ b/templates/energyplus/templates/zonehvac/hvac-zone.pxt
@@ -534,8 +534,8 @@ ZoneControl:Thermostat,
   <%= zone_name %> Thermostat Type Schedule,  !- Control Type Schedule Name
 <% if hvac_type == "UH" %>
   ThermostatSetpoint:SingleHeating,  !- Control 1 Object Type
-<%# TRC - addition for DXNH system type (no heating)
-elsif (((atu_reheat_coil_type == "NONE" || atu_reheat_coil_type == nil) && (heat_coil_type == "NONE" || heat_coil_type == nil)) && (sub_heat_type == "NONE" || sub_heat_type == nil)) %>
+<%# TRC - addition for DXNH system type (no heating) %>
+<% elsif (((atu_reheat_coil_type == "NONE" || atu_reheat_coil_type == nil) && (heat_coil_type == "NONE" || heat_coil_type == nil)) && (sub_heat_type == "NONE" || sub_heat_type == nil)) %>
   ThermostatSetpoint:SingleCooling,  !- Control 1 Object Type
 <% else %>
   ThermostatSetpoint:DualSetpoint,  !- Control 1 Object Type

--- a/templates/energyplus/templates/zonehvac/hvac-zone.pxt
+++ b/templates/energyplus/templates/zonehvac/hvac-zone.pxt
@@ -552,8 +552,8 @@ ThermostatSetpoint:SingleHeating,
   <%= zone_name %> Setpoints,  !- Name
   <%= zone_name %> Heating Setpoint Schedule;  !- Heating Setpoint Temperature Schedule Name
 
-<%# TRC - addition for DXNH system type (no heating)
-elsif (((atu_reheat_coil_type == "NONE" || atu_reheat_coil_type == nil) && (heat_coil_type == "NONE" || heat_coil_type == nil)) && (sub_heat_type == "NONE" || sub_heat_type == nil)) %>
+<%# TRC - addition for DXNH system type (no heating) %>
+<% elsif (((atu_reheat_coil_type == "NONE" || atu_reheat_coil_type == nil) && (heat_coil_type == "NONE" || heat_coil_type == nil)) && (sub_heat_type == "NONE" || sub_heat_type == nil)) %>
 Schedule:Constant,
   <%= zone_name %> Thermostat Type Schedule,  !- Name
   Thermostat Control,      !- Schedule Type Limits Name


### PR DESCRIPTION
# Pull Request (PR) Description
This bug fix adds missing "%>" and "<%" operators to hvac-zone.pxt to enclose a comment. The fix affects the thermostat schedule type for DXNH system types with no heating.

### PR Author
- [ ] Make sure the PR branch is up to date with main branch at the time of the PR submission
- [ ] Craft a succinct title that effectively encapsulates the essence of the pull request, providing a general overview of the proposed changes.
- [ ] Label the PR with at least one of the following: New Measure, Bug, or Feature.
- [ ] Provide a concise description of the measure, bug, or feature. Submit one PR per measure.
- [ ] For a new measure, attach a workbook named DEER_EnergyPlus_Modelkit_Measure_list_working.xlsx, containing only rows used for post-processing the measure.
- [ ] Add comments in the code when necessary to facilitate the review process.
- [ ] Add a comment before the added code, including the author's full name, company, and specifying if it's a bug fix, new measure, or feature.
- [ ] For a new feature or bug, demonstrate the impact on energy consumption for selected cases with justification using plots and descriptions.
- [ ] For a new measure, add a summary table showing total energy consumption per simulated case.
### PR Reviewer
- [ ] Conduct a thorough code review.
- [ ] If the branch is behind the main, merge the branch locally to check for potential conflicts.
- [ ] If a bug, locally reproduce it and compare energy consumptions before and after.
- [ ] Explore creative ways to stress-test the code.
- [ ] Locally check the error file and other outputs.
