### PR TITLE
Loadshapes output file tweaks for CEDARS compatibility - Bug

### DIFF
--- a/scripts/data transformation/Com.py
+++ b/scripts/data transformation/Com.py
@@ -720,7 +720,8 @@ StartDayToSourceYear = {
 }
 
 df_long['Sector'] = 'Com' #this is Com script, so Sector = Com
-df_long['Type'] = 'Whole Building'
+df_long['NormUnit'] = normunit
+df_long['Type (Whole Building or End Use)'] = 'Whole Building'
 df_long['Source Year'] = df_long['RunPeriod Start Day'].map(StartDayToSourceYear)
 
 df_long.rename(columns={'hr in 8760': 'Hour of Year'}, inplace=True)
@@ -728,12 +729,15 @@ df_long.rename(columns={'hr in 8760': 'Hour of Year'}, inplace=True)
 #final table fields round-up
 #note: UEC and Numunits omitted from draft long table in the final table
 df_long_final = df_long[['Sector', 'BldgType','BldgVint','BldgHVAC','BldgLoc',
-         'Type', 'Source Year', 'TechGroup', 'TechType','TechID',
+         'NormUnit', 'Type (Whole Building or End Use)',
+         'Source Year', 'TechGroup', 'TechType','TechID',
          'Hour of Year','UECproportion']] 
 #%%
 #output annual consumption of each permutation and store for later use if needed
 df_long_annual_loads = df_long[[
-        'Sector', 'BldgType','BldgVint','BldgHVAC','BldgLoc','Type','Source Year', 'TechGroup', 'TechType','TechID','annual_sum'
+        'Sector', 'BldgType','BldgVint','BldgHVAC','BldgLoc',
+        'NormUnit','Type (Whole Building or End Use)',
+        'Source Year', 'TechGroup', 'TechType','TechID','annual_sum'
          ]].drop_duplicates().reset_index(drop=True)
 
 #%%

--- a/scripts/data transformation/Com.py
+++ b/scripts/data transformation/Com.py
@@ -694,13 +694,9 @@ converted_long_df['Total_Elec_Consumption'] = converted_long_df['Total_Elec_Cons
 df_long = converted_long_df.sort_values(['BldgType','BldgLoc', 'TechID', 'hr in 8760'])
 
 #%% 
-#create groupby ids for each 8760 set
-df_long['set_id'] = (df_long['hr in 8760'].eq(1)
-                .groupby([df_long['BldgLoc'], df_long['TechID']])
-                .cumsum())
 #calculate annual consumption (no UEC involved)
 df_long['annual_sum'] = (df_long
-    .groupby(['BldgLoc', 'TechID', 'set_id'])['Total_Elec_Consumption']
+    .groupby(['BldgType', 'BldgVint', 'BldgHVAC', 'BldgLoc', 'TechID'])['Total_Elec_Consumption']
     .transform('sum'))
 
 #%%

--- a/scripts/data transformation/MFm.py
+++ b/scripts/data transformation/MFm.py
@@ -531,7 +531,8 @@ StartDayToSourceYear = {
 }
 
 df_long['Sector'] = 'Res' #this is MFm script, so Sector = Res
-df_long['Type'] = 'Whole Building'
+df_long['NormUnit'] = normunit
+df_long['Type (Whole Building or End Use)'] = 'Whole Building'
 df_long['Source Year'] = df_long['RunPeriod Start Day'].map(StartDayToSourceYear)
 
 df_long.rename(columns={'hr in 8760': 'Hour of Year'}, inplace=True)
@@ -539,13 +540,16 @@ df_long.rename(columns={'hr in 8760': 'Hour of Year'}, inplace=True)
 #final table fields round-up
 #note: UEC, Normunits, and numunits omitted in the final table
 df_long_final = df_long[['Sector', 'BldgType','BldgVint','BldgHVAC','BldgLoc',
-         'Type', 'Source Year', 'TechGroup', 'TechType','TechID',
+         'NormUnit', 'Type (Whole Building or End Use)',
+         'Source Year', 'TechGroup', 'TechType','TechID',
          'Hour of Year','UECproportion']] 
 
 #%%
 #output annual consumption of each permutation and store for later use if needed
 df_long_annual_loads = df_long[[
-        'Sector', 'BldgType','BldgVint','BldgHVAC','BldgLoc','Type','Source Year', 'TechGroup', 'TechType','TechID','annual_sum'
+        'Sector', 'BldgType','BldgVint','BldgHVAC','BldgLoc',
+        'NormUnit','Type (Whole Building or End Use)',
+        'Source Year', 'TechGroup', 'TechType','TechID','annual_sum'
          ]].drop_duplicates().reset_index(drop=True)
 #%%
 #export CEDARS long 8760 csv

--- a/scripts/data transformation/MFm.py
+++ b/scripts/data transformation/MFm.py
@@ -49,7 +49,7 @@ tech_uniques = list(np.unique((np.array(techgroup_techtypes))))
 expected_att = {
     'BldgType': ['MFm','SFm', 'DMo'],
     'Story': ['0','1','2'], # NA for Not Applicable
-    'BldgHVAC': ['rDXGF','rDXHP','rNCEH','rNCGF'],
+    'BldgHVAC': ['rDXGF','rDXHP','rNCEH','rNCGF','rNCOH','rDXHW'],
     'BldgVint': ['Ex','New'],
     'Measure': tech_uniques
 }


### PR DESCRIPTION
# Pull Request (PR) Description

Tweaks to the data transformation scripts:
- Add more residential HVAC types in cohort name quality check (e.g. SWHC045 has base case models with rNCOH, rDXHW)
- In loadshapes output file, insert NormUnit in column 6 (after BldgLoc)
- In loadshapes output file, Rename 'Type' to 'Type (Whole Building or End Use)'
- In loadshapes calculations, correct normalization step by modifying grouping

The NormUnit and Type columns were required by the version of CEDARS deemed load shape upload tool that we tested on 6/2.

### PR Author
- x ] Make sure the PR branch is up to date with main branch at the time of the PR submission
- [x] Craft a succinct title that effectively encapsulates the essence of the pull request, providing a general overview of the proposed changes.
- [x] Label the PR with at least one of the following: New Measure, Bug, or Feature.
- [X] Provide a concise description of the measure, bug, or feature. Submit one PR per measure.
- N/A For a new measure, attach a workbook named DEER_EnergyPlus_Modelkit_Measure_list_working.xlsx, containing only rows used for post-processing the measure.
- [x] Add comments in the code when necessary to facilitate the review process.
- [x] Add a comment before the added code, including the author's full name, company, and specifying if it's a bug fix, new measure, or feature.
- N/A - For a new feature or bug, demonstrate the impact on energy consumption for selected cases with justification using plots and descriptions.
- N/A - For a new measure, add a summary table showing total energy consumption per simulated case.
### PR Reviewer
- [ ] Conduct a thorough code review.
- [ ] If the branch is behind the main, merge the branch locally to check for potential conflicts.
- [ ] If a bug, locally reproduce it and compare energy consumptions before and after.
- [ ] Explore creative ways to stress-test the code.
- [ ] Locally check the error file and other outputs.
