### PR TITLE
Fix hourly natural gas meter output for commercial prototypes (Gas:Facility renamed to NaturalGas:Facility)

### DIFF
--- a/templates/energyplus/templates/custom.pxt
+++ b/templates/energyplus/templates/custom.pxt
@@ -53,7 +53,7 @@ Output:Variable,
 		
 
 Output:Meter,Electricity:Facility,hourly; !- [J]
-Output:Meter,Gas:Facility,hourly; !- [J]
+Output:Meter,NaturalGas:Facility,hourly; !- [J]
 
 ! Zone
 !Output:Variable,Perimeter_ZN_1,Zone Mean Air Temperature,hourly; !- Zone Average [C]


### PR DESCRIPTION
This PR proposes requesting the renamed `NaturalGas:Facility` meter in the shared EnergyPlus output template (`templates/energyplus/templates/custom.pxt`) so commercial prototypes emit their hourly natural gas profile again. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/319. You can sign in with your GitHub ID to claim ownership of the project.

Fixes #161.

## What's wrong

`templates/energyplus/templates/custom.pxt` requests the facility gas meter with the legacy key name `Output:Meter,Gas:Facility,hourly;`. EnergyPlus renamed that meter from `Gas:Facility` to `NaturalGas:Facility` in v9.4, and every EnergyPlus version this repository targets (22.2 and later) rejects the old name. When the requested meter does not exist, EnergyPlus does not error out the run; it emits a warning and simply writes no data for that meter, which is exactly the "Hourly NaturalGas output variable is incorrect" symptom reported in #161. This is the same defect that #6 fixed for the residential templates; it remained in the shared output template that the commercial prototypes rely on.

This template is code that runs: 26 commercial prototype roots (`prototypes/Asm/templates/root.pxt`, `prototypes/OfL/...`, etc.) render it into their model with `insert "custom.pxt"`, so the stale meter request lands in the IDF that EnergyPlus actually executes for every commercial building type.

## Reproduction at HEAD

I copied the exact meter line shipped in `custom.pxt` into a stock EnergyPlus example (`5ZoneAirCooled.idf`, which burns gas in its reheat coils) and ran it, alongside the corrected `NaturalGas:Facility` request for comparison:

```
Output:Meter,Electricity:Facility,hourly; !- [J]
Output:Meter,Gas:Facility,hourly; !- [J]          # shipped in custom.pxt
Output:Meter,NaturalGas:Facility,hourly; !- [J]   # corrected form
```

```
$ energyplus -w USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw -d out repro.idf
$ grep "invalid Key Name" out/eplusout.err
   ** Warning ** Output:Meter: invalid Key Name="GAS:FACILITY" - not found.
```

The `Gas:Facility` meter is absent from the meter dictionary (`eplusout.mtr`) entirely, so no hourly gas data is written. The corrected `NaturalGas:Facility` meter is present and carries real hourly values (e.g. `75937070.7`, `57167359.9`, `18596984.5` J). This matches both the EnergyPlus meter rename and the `Output:Meter, NaturalGas:Facility` form already used in the sibling `templates/energyplus/templates/output.pxt`.

## The change and verification

One line in `custom.pxt`: `Gas:Facility` -> `NaturalGas:Facility`. Re-running with only the fixed meter lines produces zero `invalid Key Name` warnings and the `NaturalGas:Facility [J] !Hourly` meter is written, with the run completing successfully and no new warnings versus the baseline run.

No change is needed to the per-measure `rakefile.rb` post-processing: `aggregate_profiles("Gas:Facility", ...)` locates the profile column via `header.match(column_name)`, and `Gas:Facility` matches the `NaturalGas:Facility [J](Hourly)` CSV header as a substring, so the aggregation picks up the restored column automatically once the meter is emitted. The change is backward-compatible: it only affects which meter key EnergyPlus is asked for, adds no new objects, and leaves the electricity meter and every other output untouched.

## How this was managed

This work was tracked on a live agile board imported from this repository's own issues and pull requests. The board was built from your GitHub history (221 stories imported from issues and PRs, plus labels), and this fix was carried on the story for issue #161: https://eastagiletracker.com/projects/319/stories/205373 — part of the full board at https://eastagiletracker.com/projects/319.

![board](https://raw.githubusercontent.com/eastagiletracker/DEER-Prototypes-EnergyPlus/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
