### PR TITLE
Add crankcase heater capacity to single-speed DX cooling coil

### DIFF
--- a/templates/energyplus/templates/zonehvac/res-zone-hvac-combi.pxt
+++ b/templates/energyplus/templates/zonehvac/res-zone-hvac-combi.pxt
@@ -567,8 +567,21 @@ ZoneHVAC:Baseboard:Convective:Water,
             DOE2 DX Coil EIR-FT, !- Energy Input Ratio Function of Temperature Curve Name
             DOE2 DX Coil EIR-FF, !- Energy Input Ratio Function of Flow Fraction Curve Name
         <%end%>
-            DOE2 DX Coil PLF;    !- Part Load Fraction Correlation Curve Name
-        <% end %>
+            DOE2 DX Coil PLF,    !- Part Load Fraction Correlation Curve Name
+            ,                        !- Maximum Outdoor Dry-Bulb Temperature for Compressor {C}
+            ,                        !- Nominal Time for Condensate Removal to Begin {s}
+            ,                        !- Ratio of Initial Moisture Evaporation Rate and Steady-State Latent Capacity
+            ,                        !- Maximum Cycling Rate {cycles/hr}
+            ,                        !- Latent Capacity Time Constant {s}
+            ,                        !- Condenser Air Inlet Node Name
+            AirCooled,               !- Condenser Type
+            ,                        !- Evaporative Condenser Effectiveness
+            ,                        !- Evaporative Condenser Air Flow Rate {m3/s}
+            ,                        !- Evaporative Condenser Pump Rated Power Consumption {W}
+!Solaris Technical - Behzad S. Rizi - 2026-08-17- Added crankcase heater fields for single-speed DX cooling.
+            <%= dx_crankcase_cap %>,  !- Crankcase Heater Capacity {W}
+            <%= dx_crankcase_max_temp %>;  !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+         <% end %>
     <% end %>
 
 !Heating Coils


### PR DESCRIPTION
# Pull Request (PR) Description
This PR addresses the single-speed DX cooling-coil crankcase-heater issue identified during post-merge review of PR #179 .

The single-speed cooling coil currently does not explicitly define crankcase-heater capacity, resulting in a default value of 0 W. This PR adds:

<%= dx_crankcase_cap %>

to make the single-speed implementation consistent with the existing multi-speed cooling coil.

Simulation testing confirms that the change adds the expected crankcase-heater electricity without changing cooling-coil compressor electricity. Tested heat-pump configurations are unchanged.

Fixes #225 
Related: PR #179

Main contributor: Behzad Salimian Rizi (brizi@solaris-technical.com)

**DEER Support Email: DeerSupport@guidehouse.com**

### PR Author
- [X] Make sure the PR branch is up to date with main branch at the time of the PR submission
- [X] Craft a succinct title that effectively encapsulates the essence of the pull request, providing a general overview of the proposed changes.
- [X] Label the PR with at least one of the following: New Measure, Bug, or Feature.
- [X] Provide a concise description of the measure, bug, or feature. Submit one PR per measure.
- [ ] For a new measure, attach a workbook named DEER_EnergyPlus_Modelkit_Measure_list_working.xlsx, containing only rows used for post-processing the measure.
- [X] Add comments in the code when necessary to facilitate the review process.
- [X] Add a comment before the added code, including the author's full name, company, and specifying if it's a bug fix, new measure, or feature.
- [X] For a new feature or bug, demonstrate the impact on energy consumption for selected cases with justification using plots and descriptions.
- [ ] For a new measure, add a summary table showing total energy consumption per simulated case.
### PR Reviewer
- [ ] Conduct a thorough code review.
- [ ] If the branch is behind the main, merge the branch locally to check for potential conflicts.
- [ ] If a bug, locally reproduce it and compare energy consumptions before and after.
- [ ] Explore creative ways to stress-test the code.
- [ ] Locally check the error file and other outputs.
